### PR TITLE
Fix warnings from elixir 1.4.0 rc tests

### DIFF
--- a/apps/frontend/lib/frontend/web/router.ex
+++ b/apps/frontend/lib/frontend/web/router.ex
@@ -15,7 +15,7 @@ defmodule Frontend.Router do
   end
 
   # Generate steamex auth route
-  steamex_route_auth
+  steamex_route_auth()
 
   scope "/", Frontend do
     pipe_through [:browser]

--- a/apps/kuikkadb/lib/kuikkadb/schema/permission.ex
+++ b/apps/kuikkadb/lib/kuikkadb/schema/permission.ex
@@ -20,7 +20,6 @@ defmodule KuikkaDB.Schema.Permission do
 
   @params [:name, :description]
   @required [:name]
-  @preload [:roles]
 
   @doc """
   Validate changes to role table

--- a/apps/kuikkadb/mix.exs
+++ b/apps/kuikkadb/mix.exs
@@ -13,7 +13,7 @@ defmodule KuikkaDB.Mixfile do
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      test_coverage: [tool: ExCoveralls],
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application

--- a/apps/steam/lib/steam/api.ex
+++ b/apps/steam/lib/steam/api.ex
@@ -34,7 +34,7 @@ defmodule Steam.Api do
       list -> {:ok, list}
     end
   end
-  defp parse_response(_) do
+  defp parse_response(_, _) do
     {:error, "Invalid response returned from api"}
   end
 

--- a/apps/steam/mix.exs
+++ b/apps/steam/mix.exs
@@ -12,7 +12,7 @@ defmodule Steam.Mixfile do
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      test_coverage: [tool: ExCoveralls],
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application

--- a/apps/user/lib/user.ex
+++ b/apps/user/lib/user.ex
@@ -3,7 +3,7 @@ defmodule User do
   Defines user struct for usage to other components
   """
 
-  alias User.{Role, Fireteam, Fireteamrole}
+  alias User.{Role, Fireteam}
 
   defstruct steamid: nil,
             personaname: nil,

--- a/apps/user/mix.exs
+++ b/apps/user/mix.exs
@@ -12,7 +12,7 @@ defmodule User.Mixfile do
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      test_coverage: [tool: ExCoveralls],
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application

--- a/mix.exs
+++ b/mix.exs
@@ -6,8 +6,8 @@ defmodule KuikkaWebsite.Mixfile do
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      test_coverage: [tool: ExCoveralls],
-     aliases: aliases,
-     deps: deps]
+     aliases: aliases(),
+     deps: deps()]
   end
 
   # Dependencies can be Hex packages:


### PR DESCRIPTION
This merge request removes warnings so kuikka website should now build succesfully with upcoming elixir 1.4.0 update